### PR TITLE
Fix Navbar Typo: "Portofolio" → "Portfolio" (#1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
       },
       {
         "@type": "SiteNavigationElement",
-        "name": "portfolio",
-        "url": "https://www.eki.my.id/#portfolio"
+        "name": "Portfolio",
+        "url": "https://www.eki.my.id/#Portfolio"
       },
       {
         "@type": "SiteNavigationElement",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,7 +9,7 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://www.eki.my.id/#Portofolio</loc>
+    <loc>https://www.eki.my.id/#Portfolio</loc>
     <priority>0.8</priority>
   </url>
   <url>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import Home from "./Pages/Home";
 import About from "./Pages/About";
 import AnimatedBackground from "./components/Background";
 import Navbar from "./components/Navbar";
-import Portofolio from "./Pages/Portofolio";
+import Portfolio from "./Pages/Portfolio";
 import ContactPage from "./Pages/Contact";
 import ProjectDetails from "./components/ProjectDetail";
 import WelcomeScreen from "./Pages/WelcomeScreen";
@@ -28,7 +28,7 @@ const LandingPage = ({ showWelcome, setShowWelcome }) => {
           <AnimatedBackground />
           <Home />
           <About />
-          <Portofolio />
+          <Portfolio />
           <ContactPage />
           <footer>
             <center>

--- a/src/Pages/About.jsx
+++ b/src/Pages/About.jsx
@@ -249,7 +249,7 @@ const AboutPage = () => {
                 <FileText className="w-4 h-4 sm:w-5 sm:h-5" /> Download Resume
               </button>
               </a>
-              <a href="#Portofolio" className="w-full lg:w-auto">
+              <a href="#Portfolio" className="w-full lg:w-auto">
               <button 
                 data-aos="fade-up"
                 data-aos-duration="1000"
@@ -264,7 +264,7 @@ const AboutPage = () => {
           <ProfileImage />
         </div>
 
-        <a href="#Portofolio">
+        <a href="#Portfolio">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-16 cursor-pointer">
             {statsData.map((stat) => (
               <StatCard key={stat.label} {...stat} />

--- a/src/Pages/Home.jsx
+++ b/src/Pages/Home.jsx
@@ -195,7 +195,7 @@ const Home = () => {
 
                 {/* CTA Buttons */}
                 <div className="flex flex-row gap-3 w-full justify-start" data-aos="fade-up" data-aos-delay="1400">
-                  <CTAButton href="#Portofolio" text="Projects" icon={ExternalLink} />
+                  <CTAButton href="#Portfolio" text="Projects" icon={ExternalLink} />
                   <CTAButton href="#Contact" text="Contact" icon={Mail} />
                 </div>
 

--- a/src/Pages/Portfolio.jsx
+++ b/src/Pages/Portfolio.jsx
@@ -194,7 +194,7 @@ export default function FullWidthTabs() {
 
   // Sisa dari komponen (return statement) tidak ada perubahan
   return (
-    <div className="md:px-[10%] px-[5%] w-full sm:mt-0 mt-[3rem] bg-[#030014] overflow-hidden" id="Portofolio">
+    <div className="md:px-[10%] px-[5%] w-full sm:mt-0 mt-[3rem] bg-[#030014] overflow-hidden" id="Portfolio">
       {/* Header section - unchanged */}
       <div className="text-center pb-10" data-aos="fade-up" data-aos-duration="1000">
         <h2 className="inline-block text-3xl md:text-5xl font-bold text-center mx-auto text-transparent bg-clip-text bg-gradient-to-r from-[#6366f1] to-[#a855f7]">
@@ -380,3 +380,4 @@ export default function FullWidthTabs() {
     </div>
   );
 }
+

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -9,7 +9,7 @@ const Navbar = () => {
     const navItems = [
         { href: "#Home", label: "Home" },
         { href: "#About", label: "About" },
-        { href: "#Portofolio", label: "Portofolio" },
+        { href: "#Portfolio", label: "Portfolio" },
         { href: "#Contact", label: "Contact" },
     ];
 


### PR DESCRIPTION
Description:
This PR resolves issue #1, where the navbar displayed the misspelled word "Portofolio" instead of "Portfolio".

Changes Made:
Renamed component references from Portofolio to Portfolio

Updated navbar link label and href to use correct spelling

Verified all file imports and component names reflect the correct spelling

Cleared caches and confirmed fix in local development environment

Testing:
Navigated through the website and confirmed navbar now displays "Portfolio" correctly

Clicked navbar link to ensure it correctly scrolls to the portfolio section